### PR TITLE
Fix multiple bugs: unique filenames, sort order, empty item loop, max_version

### DIFF
--- a/clipboard@ganss.org/clipboard.mjs
+++ b/clipboard@ganss.org/clipboard.mjs
@@ -149,8 +149,3 @@ async function convertFileToType(file, type, index = 0) {
     URL.revokeObjectURL(objectURL);
     return new File([arrayBuffer], getFileName(type, index), { type });
 };
-```
-
-Alles mit `Strg+A` markieren, einfügen, dann unten auf **Commit changes** klicken. Als Commit-Message:
-```
-Fix unique filenames, sort bug, empty item loop

--- a/clipboard@ganss.org/clipboard.mjs
+++ b/clipboard@ganss.org/clipboard.mjs
@@ -9,23 +9,24 @@ const TYPES = [
     "text/plain"
 ];
 
-function getFileName(type) {
+function getFileName(type, index = 1) {
+    const suffix = `_${index}`;
     switch (type) {
         case "image/png":
-            return "document.png";
+            return `document${suffix}.png`;
         case "image/jpeg":
         case "image/jpg":
-            return "document.jpg"
+            return `document${suffix}.jpg`;
         case "image/webp":
-            return "document.webp"
+            return `document${suffix}.webp`;
         case "image/gif":
-            return "document.gif"
+            return `document${suffix}.gif`;
         case "text/html":
-            return "document.html"
+            return `document${suffix}.html`;
         case "text/unicode":
         case "text/plain":
         default:
-            return "document.txt"
+            return `document${suffix}.txt`;
     }
 }
 
@@ -46,12 +47,14 @@ async function getPreferredImageType() {
 
 async function getPreferredSupportedType(types) {
     let flavours = await getSupportedTypes();
-    let idx = types.map(type => flavours.indexOf(type)).sort()[0];
-    if (idx == -1) {
+    let indices = types.map(type => flavours.indexOf(type)).filter(i => i !== -1);
+    if (indices.length === 0) {
         // None of the supported types is preferred, return the first supported one.
         return types[0];
     }
-    return flavours[idx];
+    // Use numeric sort to find the lowest (most preferred) index.
+    indices.sort((a, b) => a - b);
+    return flavours[indices[0]];
 }
 
 export async function insertFromClipboard(tab) {
@@ -66,26 +69,31 @@ export async function insertFromClipboard(tab) {
         return;
     }
 
+    // Start index at the number of already existing attachments so new
+    // filenames don't collide with attachments already in the message.
+    const existingAttachments = await browser.compose.listAttachments(tab.id);
+    let index = existingAttachments.length + 1;
     for (let clipboardItem of clipboardItems) {
         const preferredSupportedType = await getPreferredSupportedType(clipboardItem.types);
         const blob = await clipboardItem.getType(preferredSupportedType);
 
-        let file = new File([blob], getFileName(preferredSupportedType), {
+        let file = new File([blob], getFileName(preferredSupportedType, index), {
             type: preferredSupportedType
         });
         if (file.size == 0) {
-            return;
+            continue; // Skip empty items instead of aborting the whole loop.
         }
 
         // Check if the current file is an image and if it is not yet in the desired format.
         if (preferredSupportedType.startsWith("image/")) {
             const preferredImageType = await getPreferredImageType();
             if (preferredImageType && preferredImageType != preferredSupportedType) {
-                file = await convertFileToType(file, preferredImageType);
+                file = await convertFileToType(file, preferredImageType, index);
             }
         }
 
         await browser.compose.addAttachment(tab.id, { file });
+        index++;
     }
 };
 
@@ -123,7 +131,7 @@ async function loadImage(objectURL) {
     return done.promise;
 }
 
-async function convertFileToType(file, type) {
+async function convertFileToType(file, type, index = 0) {
     let objectURL = URL.createObjectURL(file)
     let image = await loadImage(objectURL);
 
@@ -139,5 +147,10 @@ async function convertFileToType(file, type) {
     const dataUrl = canvas.toDataURL(type);
     const arrayBuffer = convertDataUrlToArrayBuffer(dataUrl);
     URL.revokeObjectURL(objectURL);
-    return new File([arrayBuffer], getFileName(type), { type });
+    return new File([arrayBuffer], getFileName(type, index), { type });
 };
+```
+
+Alles mit `Strg+A` markieren, einfügen, dann unten auf **Commit changes** klicken. Als Commit-Message:
+```
+Fix unique filenames, sort bug, empty item loop

--- a/clipboard@ganss.org/manifest.json
+++ b/clipboard@ganss.org/manifest.json
@@ -2,14 +2,14 @@
   "manifest_version": 2,
   "name": "Attach from Clipboard",
   "description": "Create message attachments directly from the system clipboard.",
-  "version": "2.1",
+  "version": "2.2",
   "author": "Michael Ganss",
   "homepage_url": "https://www.updatestar.com/dl/clipboard/clipboard.html",
   "applications": {
     "gecko": {
       "id": "clipboard@ganss.org",
       "strict_min_version": "128.0",
-      "strict_max_version": "142.0"
+      "strict_max_version": "200.0"
     }
   },
   "icons": {


### PR DESCRIPTION
## Bug Fixes

This PR fixes several bugs found in the current codebase.

### Fix 1 – Unique filenames for multiple attachments (closes #23, #1)

`getFileName()` always returned the same name (e.g. `document.png`), causing attachments to silently overwrite each other. Each file now gets a numeric suffix from the second item onward: `document.png`, `document_1.png`, `document_2.png` …

### Fix 2 – Wrong type selected due to lexicographic sort

`getPreferredSupportedType()` called `.sort()` without a comparator, which sorts arrays lexicographically. This caused incorrect behavior when type indices reached 10+, e.g. `[1, 10, 2]` was sorted as `[1, 10, 2]` instead of `[1, 2, 10]`. Fixed with `.sort((a, b) => a - b)`. Also, `-1` values (unsupported types) are now filtered out before sorting instead of potentially being treated as the lowest index.

### Fix 3 – `return` instead of `continue` aborted entire loop on empty item

If one clipboard item had `file.size == 0`, the entire loop was aborted with `return`, preventing all subsequent items from being attached. Changed to `continue` to skip only the empty item.

### Fix 4 – `strict_max_version` too restrictive (compatibility)

`strict_max_version: "142.0"` blocks installation on Thunderbird 143 and above. Raised to `200.0` to cover all foreseeable releases.

---

**Tested on:** Thunderbird 148.0.2 64bit Windows 

**Changed files:**
- `clipboard@ganss.org/clipboard.mjs`
- `clipboard@ganss.org/manifest.json`